### PR TITLE
Allow GET for contact form submit

### DIFF
--- a/st_website_contact_capture/controllers/website_contact.py
+++ b/st_website_contact_capture/controllers/website_contact.py
@@ -11,9 +11,12 @@ EMAIL_RE = re.compile(r"^[^@\s]+@[^@\s]+\.[^@\s]+$")
 
 class WebsiteContactController(http.Controller):
 
-    @http.route(['/contactus/submit'], type='http', auth='public', website=True, methods=['POST'])
+    @http.route(['/contactus/submit'], type='http', auth='public', website=True, methods=['GET', 'POST'])
     def contactus_submit(self, **post):
         """Receive name/email/phone, create or update a res.partner, then redirect."""
+        if request.httprequest.method == 'GET':
+            return request.redirect('/contactus')
+
         name = (post.get('name') or '').strip()
         email = (post.get('email') or '').strip().lower()
         phone = (post.get('phone') or '').strip()


### PR DESCRIPTION
## Summary
- handle GET requests to `/contactus/submit` by redirecting to the contact page
- avoid HTTP 405 when visiting the submit URL directly

## Testing
- `python -m pytest`

------
https://chatgpt.com/codex/tasks/task_e_68a71dba593883328e9cef74cf197571