### PR TITLE
Fix contact centralisation partner creation and controller logging

### DIFF
--- a/sky_contact_centralization/__manifest__.py
+++ b/sky_contact_centralization/__manifest__.py
@@ -11,7 +11,11 @@
     'author': 'Your Name',
     'category': 'Tools',
     'depends': ['base', 'contacts', 'event', 'mass_mailing', 'website'],  # 'contacts' ensures res.partner is present
-    'data': [],
+    'data': [
+        'security/ir.model.access.csv',
+        'views/res_config_view.xml',
+    ],
+    'external_dependencies': {'python': ['phonenumbers', 'pycountry']},
     'installable': True,
     'auto_install': False,
     'license': 'LGPL-3',

--- a/sky_contact_centralization/controllers/website_contact.py
+++ b/sky_contact_centralization/controllers/website_contact.py
@@ -4,6 +4,7 @@ from odoo.http import request
 
 _logger = logging.getLogger(__name__)
 
+
 class WebsiteContactController(http.Controller):
 
     @http.route('/contactus', type='http', auth='public', website=True, methods=['GET', 'POST'])
@@ -12,8 +13,7 @@ class WebsiteContactController(http.Controller):
             return request.render('website.contactus')
 
         # Log des données reçues
-        print("===> Données POST reçues :", post)  # visible dans le terminal
-        _logger.info("===> Données POST reçues : %s", post)  # visible dans odoo.log
+        _logger.debug("===> Données POST reçues : %s", post)
 
         # Créer un partenaire automatiquement
         if post.get('name') and post.get('email'):
@@ -23,13 +23,17 @@ class WebsiteContactController(http.Controller):
                 'phone': post.get('phone'),
             }
             _logger.info("===> Création/Recherche de contact avec : %s", partner_vals)
-            partner = request.env['contact.centralisation.mixin'].create_contact_if_not_exist(partner_vals)
+            request.env['contact.centralisation.mixin'].create_contact_if_not_exist(partner_vals)
 
         # Garder l'action d'envoi d'email existante
-        template = request.env.ref('website_form.website_contactus_form')
+        template = request.env.ref('website_form.website_contactus_form', raise_if_not_found=False)
         if template:
             _logger.info("===> Envoi de l'email via le template ID %s", template.id)
-            request.env['mail.template'].sudo().browse(template.id).send_mail(request.website.id, force_send=True)
+            request.env['mail.template'].sudo().browse(template.id).send_mail(
+                request.website.id, force_send=True
+            )
+        else:
+            _logger.warning("Template website_form.website_contactus_form not found")
 
         # Redirection vers la page de remerciement
         _logger.info("===> Redirection vers /contactus-thank-you")

--- a/sky_contact_centralization/models/event_registration.py
+++ b/sky_contact_centralization/models/event_registration.py
@@ -1,5 +1,6 @@
 from odoo import models, api
 
+
 class EventRegistration(models.Model):
     _inherit = 'event.registration'
 
@@ -17,7 +18,7 @@ class EventRegistration(models.Model):
             partner = self.env['contact.centralisation.mixin'].create_contact_if_not_exist(contact_data)
 
             # Injecte le partner_id dans les valeurs
-            #vals['partner_id'] = partner
+            vals['partner_id'] = partner
 
         # Appel au create original avec le partner_id mis à jour
         return super(EventRegistration, self).create(vals)

--- a/sky_contact_centralization/models/mailing_contact.py
+++ b/sky_contact_centralization/models/mailing_contact.py
@@ -1,21 +1,21 @@
 from odoo import models, api
 
+
 class MailingContact(models.Model):
     _inherit = 'mailing.contact'
 
     @api.model
     def create(self, vals):
-
         contact_data = {
             'name': vals.get('name'),
-            'email': vals.get('email')
+            'email': vals.get('email'),
         }
 
         # Appel à la fonction pour créer ou retrouver le contact
         partner = self.env['contact.centralisation.mixin'].create_contact_if_not_exist(contact_data)
 
         # Injecte le partner_id dans les valeurs
-        #vals['partner_id'] = partner
+        vals['partner_id'] = partner
 
         # Appel au create original avec le partner_id mis à jour
         return super(MailingContact, self).create(vals)

--- a/sky_contact_centralization/models/sky_contact_centralization.py
+++ b/sky_contact_centralization/models/sky_contact_centralization.py
@@ -6,7 +6,7 @@ class ContactCentralisationMixin(models.AbstractModel):
     _name = 'contact.centralisation.mixin'
     _description = 'Automatically sync records into res.partner'
 
-    def normalize_phone_number(self,phone, default_region='CM'):
+    def normalize_phone_number(self, phone, default_region='CM'):
         """
         Normalise un numéro de téléphone en format international (E.164).
         Si invalide, retourne uniquement les chiffres du numéro d'origine.
@@ -30,6 +30,7 @@ class ContactCentralisationMixin(models.AbstractModel):
         # fallback: supprimer tout ce qui n'est pas chiffre
         return ''.join(c for c in phone if c.isdigit())
 
+    @staticmethod
     def get_country_code(country_name):
         country = pycountry.countries.get(name=country_name)
         if not country:
@@ -66,9 +67,11 @@ class ContactCentralisationMixin(models.AbstractModel):
                 '|', ('phone', '!=', False), ('mobile', '!=', False)
             ])
             for p in potential_partners:
-                if (self.normalize_phone_number(p.phone, 'CM') == phone_normalized or
-                        self.normalize_phone_number(p.mobile, 'CM') == phone_normalized):
-                    return partner.id
+                if (
+                    self.normalize_phone_number(p.phone, 'CM') == phone_normalized
+                    or self.normalize_phone_number(p.mobile, 'CM') == phone_normalized
+                ):
+                    return p.id
 
         # 3. Recherche par nom uniquement si aucun email ou téléphone n'est renseigné
         partner_by_name = partner_obj.search([


### PR DESCRIPTION
## Summary
- return the matched partner when phone numbers match
- set `partner_id` in event registrations and mailing contacts
- declare python dependencies and data files in manifest
- replace prints with logging and handle missing email template
- make `website_form` an optional dependency

## Testing
- `python -m py_compile sky_contact_centralization/models/*.py sky_contact_centralization/controllers/*.py`
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68a8314d0d8c8332b22a297fb4e02bd0