### PR TITLE
Enable partner creation from website contact form

### DIFF
--- a/sky_contact_centralization/controllers/website_contact.py
+++ b/sky_contact_centralization/controllers/website_contact.py
@@ -1,8 +1,5 @@
-import logging
 from odoo import http
 from odoo.http import request
-
-_logger = logging.getLogger(__name__)
 
 
 class WebsiteContactController(http.Controller):
@@ -12,9 +9,6 @@ class WebsiteContactController(http.Controller):
         if request.httprequest.method == 'GET':
             return request.render('website.contactus')
 
-        # Log des données reçues
-        _logger.debug("===> Données POST reçues : %s", post)
-
         # Créer un partenaire automatiquement
         if post.get('name') and post.get('email'):
             partner_vals = {
@@ -22,19 +16,13 @@ class WebsiteContactController(http.Controller):
                 'email': post.get('email'),
                 'phone': post.get('phone'),
             }
-            _logger.info("===> Création/Recherche de contact avec : %s", partner_vals)
-            request.env['contact.centralisation.mixin'].create_contact_if_not_exist(partner_vals)
+            request.env['contact.centralisation.mixin'].sudo().create_contact_if_not_exist(partner_vals)
 
         # Garder l'action d'envoi d'email existante
         template = request.env.ref('website_form.website_contactus_form', raise_if_not_found=False)
         if template:
-            _logger.info("===> Envoi de l'email via le template ID %s", template.id)
             request.env['mail.template'].sudo().browse(template.id).send_mail(
                 request.website.id, force_send=True
             )
-        else:
-            _logger.warning("Template website_form.website_contactus_form not found")
 
-        # Redirection vers la page de remerciement
-        _logger.info("===> Redirection vers /contactus-thank-you")
         return request.redirect('/contactus-thank-you')

--- a/sky_contact_centralization/models/sky_contact_centralization.py
+++ b/sky_contact_centralization/models/sky_contact_centralization.py
@@ -53,7 +53,7 @@ class ContactCentralisationMixin(models.AbstractModel):
         name = values.get('name')
 
         phone_normalized = self.normalize_phone_number(phone_raw, 'CM')
-        partner_obj = self.env['res.partner']
+        partner_obj = self.env['res.partner'].sudo()
 
         # 1. Recherche par email
         partner = partner_obj.search([('email', '=', email)], limit=1)


### PR DESCRIPTION
## Summary
- Sudo contact centralisation mixin when creating partners from website contact form
- Use sudo on res.partner inside ContactCentralisationMixin
- Remove debugging prints from website contact controller

## Testing
- `python -m py_compile sky_contact_centralization/controllers/website_contact.py sky_contact_centralization/models/sky_contact_centralization.py`


------
https://chatgpt.com/codex/tasks/task_e_68a8482820588332a91f789c96f57874