### PR TITLE
Allow GET requests for contact form

### DIFF
--- a/sky_contact_centralization/controllers/website_contact.py
+++ b/sky_contact_centralization/controllers/website_contact.py
@@ -10,7 +10,7 @@ CONTACT_TEMPLATE = 'website_form.website_contactus_form'
 
 class WebsiteContactController(http.Controller):
 
-    @http.route(['/contactus'], type='http', auth="public", website=True, methods=['POST'])
+    @http.route(['/contactus'], type='http', auth="public", website=True, methods=['GET', 'POST'])
     def website_contact_us(self, **post):
         """Handle submissions from the contact us form.
 
@@ -19,6 +19,9 @@ class WebsiteContactController(http.Controller):
         partner is created or updated via the ``contact.centralisation.mixin``
         helper before the e-mail is dispatched.
         """
+        if request.httprequest.method == 'GET':
+            return request.render('website.contactus', {})
+
         _logger.info("===> Données POST reçues : %s", post)
 
         template = None


### PR DESCRIPTION
## Summary
- handle GET requests for `/contactus` route so the contact page renders instead of returning 405

## Testing
- `pytest`
- `python -m py_compile sky_contact_centralization/controllers/website_contact.py`

------
https://chatgpt.com/codex/tasks/task_e_68a9a1bdccc083329ec71f53c9b6b187