### PR TITLE
feat: loosen website lead check

### DIFF
--- a/sky_contact_centralisation/models/crm_lead.py
+++ b/sky_contact_centralisation/models/crm_lead.py
@@ -11,7 +11,12 @@ class CrmLead(models.Model):
         lead = super().create(vals)
 
         # Try to limit to leads that likely come from the website
-        is_websiteish = bool(lead.email_from or lead.contact_name) and bool(lead.description)
+        # The Contact Us form may not always supply a description/message.
+        # Also honour the flag Odoo's website form sets in context so we don't
+        # accidentally process unrelated leads.
+        is_websiteish = self.env.context.get("website_form_input") or bool(
+            lead.email_from or lead.contact_name
+        )
 
         if is_websiteish:
             payload = {


### PR DESCRIPTION
## Summary
- broaden website lead filtering so Contact Us submissions without description still create contacts
- revert unrelated contact form handler changes to keep scope on `sky_contact_centralisation`

## Testing
- `python -m py_compile sky_contact_centralisation/models/crm_lead.py st_website_contact_capture/controllers/website_contact.py`


------
https://chatgpt.com/codex/tasks/task_e_68aedc7d2c748332822cee6196974d49