### PR TITLE
Intercept contact form for centralisation

### DIFF
--- a/sky_contact_centralisation/__init__.py
+++ b/sky_contact_centralisation/__init__.py
@@ -1,2 +1,2 @@
-
+from . import controllers
 from . import models

--- a/sky_contact_centralisation/__manifest__.py
+++ b/sky_contact_centralisation/__manifest__.py
@@ -15,7 +15,7 @@
         'security/ir.model.access.csv',
         'views/res_config_view.xml',
     ],
-    'external_dependencies': {'python': ['phonenumbers', 'pycountry']},
+    'external_dependencies': {'python': ['phonenumbers', 'pycountry', 'email_validator']},
     'installable': True,
     'auto_install': False,
     'license': 'LGPL-3',

--- a/sky_contact_centralisation/controllers/__init__.py
+++ b/sky_contact_centralisation/controllers/__init__.py
@@ -1,0 +1,1 @@
+from . import website_contact

--- a/sky_contact_centralisation/controllers/website_contact.py
+++ b/sky_contact_centralisation/controllers/website_contact.py
@@ -1,0 +1,33 @@
+# -*- coding: utf-8 -*-
+import logging
+
+from odoo.http import request
+from odoo.addons.website_form.controllers.main import WebsiteForm as WebsiteFormController
+from email_validator import EmailNotValidError, validate_email
+
+_logger = logging.getLogger(__name__)
+
+
+class WebsiteForm(WebsiteFormController):
+    """Override the default website form submit to capture Contact Us data."""
+
+    def website_form(self, model_name, **kwargs):
+        # Run contact centralisation before delegating to Odoo's controller
+        if model_name == 'crm.lead':
+            name = (kwargs.get('contact_name') or kwargs.get('name') or '').strip()
+            email = (kwargs.get('email_from') or '').strip().lower()
+            phone = (kwargs.get('phone') or '').strip()
+
+            try:
+                email = validate_email(email).email
+                request.env['contact.centralisation.mixin'].sudo().create_contact_if_not_exist({
+                    'name': name or email.split('@')[0],
+                    'email': email,
+                    'phone': phone,
+                })
+            except EmailNotValidError:
+                _logger.warning("Invalid email '%s' in contact form", email)
+            except Exception:
+                _logger.exception("Failed to centralise contact from website form")
+
+        return super().website_form(model_name, **kwargs)


### PR DESCRIPTION
## Summary
- Capture Contact Us form submissions by overriding `/website_form/submit`
- Wire module controllers and require `email_validator`

## Testing
- `python3 -m compileall -q sky_contact_centralisation`


------
https://chatgpt.com/codex/tasks/task_e_68aee54bf6108332992d768569bbbfff